### PR TITLE
feat: xcelerate-demo 서비스 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,21 @@ services:
       PAYMENT_NICEPAY_MERCHANT_KEY: ${PAYMENT_NICEPAY_MERCHANT_KEY}
       PAYMENT_NICEPAY_MID: ${PAYMENT_NICEPAY_MID}
 
+  # xcelerate 데모
+  xcelerate-demo:
+    image: ghcr.io/dev-montyoh/xcelerate-demo:latest
+    container_name: xcelerate-demo
+    ports:
+      - "8082:8080"
+    networks:
+      backend-network:
+    restart: always
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      XCELERATE_DB_URL: ${XCELERATE_DB_URL}
+      XCELERATE_DB_USERNAME: ${XCELERATE_DB_USERNAME}
+      XCELERATE_DB_PASSWORD: ${XCELERATE_DB_PASSWORD}
+
   # 프론트
   frontend-portfolio:
     image: ghcr.io/dev-montyoh/frontend-portfolio:latest

--- a/scripts/lightsail_application_instance_userdata.sh
+++ b/scripts/lightsail_application_instance_userdata.sh
@@ -5,7 +5,7 @@ apt-get update -y
 # ----------------------
 # Docker 설치
 # ----------------------
-apt-get install -y ca-certificates curl gnupg
+apt-get install -y ca-certificates curl gnupg jq
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 chmod a+r /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
## Summary
- docker-compose.yml에 xcelerate-demo 서비스 추가
- 포트: 8082 (host) → 8080 (container)
- prod 프로필로 실행, xcelerate 전용 DB 환경변수 주입

## 전제 조건
- DB 서버에 `xcelerate` 데이터베이스 및 `xcelerate_user` 생성 필요
- secrets-store `database.properties`에 `XCELERATE_DB_*` 변수 추가 완료