### PR TITLE
feat: Lightsail 애플리케이션 인스턴스 복원 및 OCI 비활성화

### DIFF
--- a/aws/aws.tf
+++ b/aws/aws.tf
@@ -10,10 +10,11 @@ module "iam" {
 }
 
 module "lightsail" {
-  source             = "./lightsail"
-  AWS_SSH_PUBLIC_KEY = var.AWS_SSH_PUBLIC_KEY
-  DB_USERNAME        = var.DB_USERNAME
-  DB_PASSWORD        = var.DB_PASSWORD
+  source                      = "./lightsail"
+  AWS_SSH_PUBLIC_KEY          = var.AWS_SSH_PUBLIC_KEY
+  DB_USERNAME                 = var.DB_USERNAME
+  DB_PASSWORD                 = var.DB_PASSWORD
+  AWS_EC2_USERDATA_GHCR_TOKEN = var.AWS_EC2_USERDATA_GHCR_TOKEN
 }
 
 module "billing" {

--- a/aws/lightsail/lightsail.tf
+++ b/aws/lightsail/lightsail.tf
@@ -1,3 +1,60 @@
+# 애플리케이션 Lightsail 인스턴스
+resource "aws_lightsail_static_ip" "application_lightsail_static_ip" {
+  name = "application_lightsail_static_ip"
+}
+
+resource "aws_lightsail_instance" "application_instance" {
+  name              = "MONTY_APPLICATION_INSTANCE"
+  bundle_id         = "small_3_0"
+  blueprint_id      = "ubuntu_22_04"
+  key_pair_name     = module.aws_lightsail_key_pair.aws_lightsail_key.name
+  availability_zone = "ap-northeast-2a"
+  user_data = templatefile("scripts/lightsail_application_instance_userdata.sh",
+    {
+      AWS_EC2_USERDATA_GHCR_TOKEN = var.AWS_EC2_USERDATA_GHCR_TOKEN
+    }
+  )
+  depends_on = [module.aws_lightsail_key_pair]
+}
+
+resource "aws_lightsail_static_ip_attachment" "application_lightsail_static_ip_attachment" {
+  instance_name  = aws_lightsail_instance.application_instance.name
+  static_ip_name = aws_lightsail_static_ip.application_lightsail_static_ip.name
+  depends_on     = [aws_lightsail_static_ip.application_lightsail_static_ip, aws_lightsail_instance.application_instance]
+}
+
+resource "aws_lightsail_instance_public_ports" "application_firewall" {
+  instance_name = aws_lightsail_instance.application_instance.name
+
+  port_info {
+    protocol  = "tcp"
+    from_port = 22
+    to_port   = 22
+  }
+
+  port_info {
+    protocol  = "tcp"
+    from_port = 80
+    to_port   = 80
+    cidrs     = ["0.0.0.0/0"]
+  }
+
+  port_info {
+    protocol  = "tcp"
+    from_port = 443
+    to_port   = 443
+    cidrs     = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    ignore_changes = [
+      port_info
+    ]
+  }
+
+  depends_on = [aws_lightsail_instance.application_instance]
+}
+
 # 데이터베이스 Lightsail 인스턴스
 resource "aws_lightsail_static_ip" "database_lightsail_static_ip" {
   name = "database_lightsail_static_ip"

--- a/aws/lightsail/output.tf
+++ b/aws/lightsail/output.tf
@@ -1,3 +1,7 @@
+output "service_server_public_ip" {
+  value = aws_lightsail_static_ip.application_lightsail_static_ip.ip_address
+}
+
 output "database_server_public_ip" {
   value = aws_lightsail_static_ip.database_lightsail_static_ip.ip_address
 }

--- a/aws/lightsail/variable.tf
+++ b/aws/lightsail/variable.tf
@@ -1,3 +1,4 @@
-variable "AWS_SSH_PUBLIC_KEY" { type = string }
-variable "DB_PASSWORD"        { type = string }
-variable "DB_USERNAME"        { type = string }
+variable "AWS_SSH_PUBLIC_KEY"          { type = string }
+variable "DB_PASSWORD"                { type = string }
+variable "DB_USERNAME"                { type = string }
+variable "AWS_EC2_USERDATA_GHCR_TOKEN" { type = string }

--- a/aws/output.tf
+++ b/aws/output.tf
@@ -1,3 +1,7 @@
+output "service_server_public_ip" {
+  value = module.lightsail.service_server_public_ip
+}
+
 output "database_server_public_ip" {
   value = module.lightsail.database_server_public_ip
 }

--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,6 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "5.11.0"
     }
-    # Oracle Cloud Infrastructure
-    oci = {
-      source  = "oracle/oci"
-      version = "~> 6.0"
-    }
   }
 }
 
@@ -29,20 +24,6 @@ provider "cloudflare" {
   api_token = var.CLOUDFLARE_API_TOKEN
 }
 
-provider "oci" {
-  tenancy_ocid = var.OCI_TENANCY_OCID
-  user_ocid    = var.OCI_USER_OCID
-  fingerprint  = var.OCI_FINGERPRINT
-  region       = var.OCI_REGION
-  private_key  = var.OCI_PRIVATE_KEY
-}
-
-module "oci" {
-  source                  = "./oci"
-  OCI_TENANCY_OCID        = var.OCI_TENANCY_OCID
-  OCI_SSH_PUBLIC_KEY      = var.AWS_EC2_SSH_PUBLIC_KEY
-  OCI_USERDATA_GHCR_TOKEN = var.AWS_EC2_USERDATA_GHCR_TOKEN
-}
 
 module "aws" {
   source                      = "./aws"
@@ -59,9 +40,9 @@ module "aws" {
 
 module "cloudflare" {
   source                         = "./cloudflare"
-  service_server_public_ip       = module.oci.service_server_public_ip
+  service_server_public_ip       = module.aws.service_server_public_ip
   database_server_public_ip      = module.aws.database_server_public_ip
-  depends_on                     = [module.aws, module.oci]
+  depends_on                     = [module.aws]
   CLOUDFLARE_ZONE_ID             = var.CLOUDFLARE_ZONE_ID
   CLOUDFLARE_ZONE_ID_MONTYOH_DEV = var.CLOUDFLARE_ZONE_ID_MONTYOH_DEV
   CLOUDFLARE_ACCOUNT_ID          = var.CLOUDFLARE_ACCOUNT_ID

--- a/variable.tf
+++ b/variable.tf
@@ -48,13 +48,3 @@ variable "CLOUDFLARE_ACCOUNT_ID" { type = string }
 variable "AWS_EC2_USERDATA_GHCR_TOKEN" { type = string }
 variable "DB_PASSWORD" { type = string }
 variable "DB_USERNAME" { type = string }
-
-# OCI
-variable "OCI_TENANCY_OCID"  { type = string }
-variable "OCI_USER_OCID"     { type = string }
-variable "OCI_FINGERPRINT"   { type = string }
-variable "OCI_REGION"        { type = string }
-variable "OCI_PRIVATE_KEY" {
-  type      = string
-  sensitive = true
-}


### PR DESCRIPTION
## Summary
- Lightsail 애플리케이션 인스턴스 복원 (`small_3_0`, 2GB RAM, $12/월)
- Static IP, 방화벽(22/80/443) 복원
- OCI provider/module `main.tf`에서 제거 (코드는 `./oci/` 폴더에 보존)
- Cloudflare DNS IP 참조를 `module.aws`로 복원

## Test plan
- [ ] Terraform Cloud speculative plan 확인
- [ ] plan 이상 없으면 머지 후 apply 확인
- [ ] Lightsail 인스턴스 생성 및 Static IP 할당 확인
- [ ] Cloudflare DNS 업데이트 확인
- [ ] SSH 접속 및 서비스 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)