### PR TITLE
chore: DB 인스턴스 사양 업그레이드 (nano → micro)

### DIFF
--- a/aws/lightsail/lightsail.tf
+++ b/aws/lightsail/lightsail.tf
@@ -67,7 +67,7 @@ module "aws_lightsail_key_pair" {
 
 resource "aws_lightsail_instance" "db_instance" {
   name              = "MONTY_DATABASE_INSTANCE"
-  bundle_id         = "nano_3_0"
+  bundle_id         = "micro_3_0"
   blueprint_id      = "ubuntu_22_04"
   key_pair_name     = module.aws_lightsail_key_pair.aws_lightsail_key.name
   availability_zone = "ap-northeast-2a"


### PR DESCRIPTION
OOM 방지를 위해 DB 인스턴스 0.5GB → 1GB RAM 업그레이드 ( → /월)