### PR TITLE
chore: DB 번들 nano_3_0으로 다운그레이드

### DIFF
--- a/aws/lightsail/lightsail.tf
+++ b/aws/lightsail/lightsail.tf
@@ -71,7 +71,7 @@ module "aws_lightsail_key_pair" {
 
 resource "aws_lightsail_instance" "db_instance" {
   name              = "MONTY_DATABASE_INSTANCE"
-  bundle_id         = "micro_3_0"
+  bundle_id         = "nano_3_0"
   blueprint_id      = "ubuntu_22_04"
   key_pair_name     = module.aws_lightsail_key_pair.aws_lightsail_key.name
   availability_zone = "ap-northeast-2a"


### PR DESCRIPTION
## Summary
- DB 인스턴스 `micro_3_0` ($7) → `nano_3_0` ($5)으로 복원
- 300만 건 기준으로 충분히 커버 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)