### PR TITLE
chore: OCI 애플리케이션 인스턴스 사양 다운그레이드 (4/24 → 2/12)

### DIFF
--- a/oci/oci.tf
+++ b/oci/oci.tf
@@ -24,7 +24,7 @@ module "app_instance" {
   user_data           = templatefile("${path.module}/../scripts/oci_application_instance_userdata.sh", {
     GHCR_TOKEN = var.GHCR_TOKEN
   })
-  ocpus               = 4
-  memory_in_gbs       = 24
+  ocpus               = 2
+  memory_in_gbs       = 12
   depends_on          = [module.networking]
 }


### PR DESCRIPTION
## Summary
- OCI 애플리케이션 인스턴스 사양 조정
- ocpus: 4 → 2
- memory_in_gbs: 24 → 12

## Test plan
- [ ] Terraform Plan 확인
- [ ] Terraform Apply 후 OCI 콘솔에서 인스턴스 사양 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)