### PR TITLE
OCI 인스턴스 사양을 4 OCPU와 24GB로 상향

### DIFF
--- a/oci/oci.tf
+++ b/oci/oci.tf
@@ -25,8 +25,8 @@ module "app_instance" {
   user_data = templatefile("${path.module}/../scripts/oci_application_instance_userdata.sh", {
     GHCR_TOKEN = var.GHCR_TOKEN
   })
-  ocpus         = 2
-  memory_in_gbs = 12
+  ocpus         = 4
+  memory_in_gbs = 24
   depends_on    = [module.networking]
 }
 


### PR DESCRIPTION
## 변경 사항
- OCI 애플리케이션 인스턴스의 ocpus 값을 2에서 4로 상향했습니다.
- OCI 애플리케이션 인스턴스의 memory_in_gbs 값을 12에서 24로 상향했습니다.

## 참고
- 저장소의 기본 브랜치가 main이 아니라 master라서 master 대상으로 PR을 생성했습니다.
- terraform fmt oci/oci.tf 는 실행했습니다.
- terraform validate 는 별도 provider 초기화 여부를 확인하지 않아 실행하지 않았습니다.