### PR TITLE
feat: Core Keeper 게임 서버 DNS 및 방화벽 포트 추가

### DIFF
--- a/cloudflare/cloudflare.tf
+++ b/cloudflare/cloudflare.tf
@@ -62,6 +62,17 @@ resource "cloudflare_dns_record" "montyoh_dev_payment" {
   proxied = true
 }
 
+##  서브 도메인 - Core Keeper 게임 서버
+resource "cloudflare_dns_record" "montyoh_dev_corekeeper" {
+  zone_id = var.CLOUDFLARE_ZONE_ID_MONTYOH_DEV
+  name    = "corekeeper.montyoh.dev"
+  ttl     = 1
+  type    = "A"
+  comment = "corekeeper.montyoh.dev record"
+  content = var.oci_instance_public_ip
+  proxied = false
+}
+
 ##  서브 도메인 - Xcelerate Demo
 resource "cloudflare_dns_record" "montyoh_dev_xcelerate" {
   zone_id = var.CLOUDFLARE_ZONE_ID_MONTYOH_DEV

--- a/oci/oci.tf
+++ b/oci/oci.tf
@@ -10,7 +10,7 @@ module "networking" {
   cidr_block        = "10.0.0.0/16"
   subnet_cidr       = "10.0.1.0/24"
   ingress_ports     = [22, 80, 443, 5432]
-  udp_ingress_ports = []
+  udp_ingress_ports = [27015]
 }
 
 # 애플리케이션 인스턴스 (앱 + 데이터베이스)


### PR DESCRIPTION
## Summary
- OCI Security List: UDP 27015 인바운드 오픈
- Cloudflare DNS: `corekeeper.montyoh.dev` A 레코드 추가 (`proxied=false`)

## Test plan
- [ ] Terraform apply 후 `nslookup corekeeper.montyoh.dev` 확인
- [ ] 서버 내부 iptables UDP 27015 허용 후 게임 클라이언트 접속 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)