### PR TITLE
refactor: gateway 내부 포트 80 통일 및 호스트 포트 노출 제거

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,14 +53,13 @@ services:
   backend-api-server-gateway:
     image: ghcr.io/dev-montyoh/backend-api-server-gateway:latest
     container_name: backend-api-server-gateway
-    ports:
-      - "3000:3000"
     networks:
       backend-network:
     restart: always
     environment:
       SPRING_PROFILES_ACTIVE: prod
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      SERVER_PORT: 80
 
   # auth
   backend-api-server-auth:


### PR DESCRIPTION
## Summary

- `backend-api-server-gateway` 컨테이너 호스트 포트 노출(`3000:3000`) 제거
- `SERVER_PORT: 80` 환경변수 추가로 컨테이너 내부 포트 80으로 통일
- nginx에서 컨테이너명으로 직접 통신하므로 호스트 포트 노출 불필요

## 변경 배경

nginx proxy가 도메인 기반으로 라우팅하므로 서비스들이 호스트 포트를 노출할 필요가 없음.
내부 서비스 간 통신은 Docker 컨테이너명으로 처리하며, 포트를 80으로 통일하여 관리 단순화.

## Test plan

- [ ] gateway 컨테이너 정상 기동 확인 (포트 80)
- [ ] nginx → gateway 라우팅 정상 동작 확인
- [ ] `/api` 경로 API 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)