### PR TITLE
feat: frontend-portfolio Redis 내부 캐시 연결 및 포트 정리

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,11 +146,16 @@ services:
   frontend-portfolio:
     image: ghcr.io/dev-montyoh/frontend-portfolio:latest
     container_name: frontend-portfolio
-    ports:
-      - "8080:8080"
     networks:
       backend-network:
     restart: always
+    depends_on:
+      redis:
+        condition: service_healthy
+    environment:
+      PORT: 80
+      REDIS_URL: redis://redis:6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
 
   frontend-payment:
     image: ghcr.io/dev-montyoh/frontend-payment:latest


### PR DESCRIPTION
- 직접 포트 노출(8080:8080) 제거 → nginx 프록시 경유로 통일
- PORT=80 주입으로 내부 포트 다른 서비스와 통일
- Redis 내부 주소(redis://redis:6379) 및 비밀번호 환경변수 주입
- Redis 헬스체크 통과 후 기동하도록 depends_on 추가