### PR TITLE
feat: Vikunja 프로젝트 관리 서비스 추가

### DIFF
--- a/.github/workflows/manual-redeploy-vikunja.yml
+++ b/.github/workflows/manual-redeploy-vikunja.yml
@@ -1,0 +1,69 @@
+name: manual-redeploy-vikunja
+
+on:
+  workflow_dispatch:
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Check out Secrets store
+        uses: actions/checkout@v5
+        with:
+          repository: 'dev-montyoh/secrets-store'
+          token: ${{ secrets.SECRETS_STORE_ACCESS_TOKEN }}
+          path: secrets-store
+
+      - name: Load secrets
+        uses: ./secrets-store/.github/actions/load-secrets
+        with:
+          SECRETS_STORE_ACCESS_TOKEN: ${{ secrets.SECRETS_STORE_ACCESS_TOKEN }}
+
+      - name: ENV to JSON
+        id: set_env_json
+        run: |
+          echo "ENV_VARS_JSON=$(echo '${{ toJSON(env) }}' | jq -c '.')" >> $GITHUB_OUTPUT
+
+      - name: Redeploy Vikunja to Oracle
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ssh.montyoh.dev
+          username: ubuntu
+          key_path: ./secrets-store/key/ec2-ssh-key
+          script: |
+            ENV_JSON='${{ steps.set_env_json.outputs.ENV_VARS_JSON }}'
+            eval $(echo "$ENV_JSON" | jq -r '
+              to_entries[]
+              | select((.key | startswith("GITHUB_") | not) and (.key | startswith("RUNNER_") | not))
+              | "export \(.key)=\"\(.value)\";"
+            ' | tr -d '\n')
+
+            docker ps -q --filter "name=vikunja" | xargs -r docker stop
+            docker ps -a -q --filter "name=vikunja" | xargs -r docker rm
+
+            cd /home/ubuntu/app
+            curl -L -o docker-compose.yml https://raw.githubusercontent.com/${{ github.repository_owner }}/iac-terraform/refs/heads/master/docker-compose.yml
+
+            # Vikunja 전용 유저 생성 (없을 경우에만)
+            docker exec postgres psql -U "$DB_USERNAME" -d postgres -c \
+              "DO \$\$ BEGIN
+                IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='$VIKUNJA_DB_USERNAME') THEN
+                  CREATE USER \"$VIKUNJA_DB_USERNAME\" WITH PASSWORD '$VIKUNJA_DB_PASSWORD';
+                END IF;
+              END \$\$;"
+
+            # Vikunja 전용 DB 생성 (없을 경우에만)
+            docker exec postgres psql -U "$DB_USERNAME" -d postgres -tc \
+              "SELECT 1 FROM pg_database WHERE datname='$VIKUNJA_DB_NAME'" | grep -q 1 \
+              || docker exec postgres psql -U "$DB_USERNAME" -d postgres -c \
+                "CREATE DATABASE \"$VIKUNJA_DB_NAME\" OWNER \"$VIKUNJA_DB_USERNAME\";"
+
+            # 권한 부여
+            docker exec postgres psql -U "$DB_USERNAME" -d postgres -c \
+              "GRANT ALL PRIVILEGES ON DATABASE \"$VIKUNJA_DB_NAME\" TO \"$VIKUNJA_DB_USERNAME\";"
+
+            docker-compose up -d vikunja

--- a/cloudflare/cloudflare.tf
+++ b/cloudflare/cloudflare.tf
@@ -147,6 +147,17 @@ resource "cloudflare_dns_record" "montyoh_dev_plane" {
   proxied = true
 }
 
+##  서브 도메인 - Vikunja (프로젝트 관리)
+resource "cloudflare_dns_record" "montyoh_dev_vikunja" {
+  zone_id = var.CLOUDFLARE_ZONE_ID_MONTYOH_DEV
+  name    = "vikunja.montyoh.dev"
+  ttl     = 1
+  type    = "A"
+  comment = "vikunja.montyoh.dev record"
+  content = var.oci_instance_public_ip
+  proxied = true
+}
+
 # Workers - 서버 다운 시 공사중 페이지
 resource "cloudflare_workers_script" "maintenance" {
   account_id  = var.CLOUDFLARE_ACCOUNT_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -403,6 +403,34 @@ services:
       backend-network:
     restart: always
 
+  # ── Vikunja (할 일 / 프로젝트 관리) ─────────────────────────────
+  vikunja:
+    image: vikunja/vikunja:latest
+    container_name: vikunja
+    environment:
+      VIKUNJA_DATABASE_TYPE: postgres
+      VIKUNJA_DATABASE_HOST: postgres
+      VIKUNJA_DATABASE_DATABASE: ${VIKUNJA_DB_NAME}
+      VIKUNJA_DATABASE_USER: ${VIKUNJA_DB_USERNAME}
+      VIKUNJA_DATABASE_PASSWORD: ${VIKUNJA_DB_PASSWORD}
+      VIKUNJA_SERVICE_JWTSECRET: ${VIKUNJA_JWT_SECRET}
+      VIKUNJA_SERVICE_FRONTENDURL: https://vikunja.montyoh.dev/
+      VIKUNJA_FILES_TYPE: s3
+      VIKUNJA_FILES_S3_ENDPOINT: ${CLOUDFLARE_R2_END_POINT}
+      VIKUNJA_FILES_S3_BUCKET: ${PLANE_R2_BUCKET}
+      VIKUNJA_FILES_S3_REGION: auto
+      VIKUNJA_FILES_S3_ACCESSKEY: ${PLANE_R2_ACCESS_KEY}
+      VIKUNJA_FILES_S3_SECRETKEY: ${PLANE_R2_SECRET_KEY}
+      VIKUNJA_FILES_S3_USEPATHSTYLE: "true"
+    networks:
+      backend-network:
+        aliases:
+          - vikunja
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: always
+
 networks:
   backend-network:
     driver: bridge


### PR DESCRIPTION
## Summary

- `docker-compose.yml`: vikunja 서비스 추가 (PostgreSQL 연동, Cloudflare R2 S3 파일 스토리지)
- `cloudflare/cloudflare.tf`: `vikunja.montyoh.dev` DNS 레코드 추가
- `.github/workflows/manual-redeploy-vikunja.yml`: 배포 워크플로우 추가 (DB 자동 생성 포함)
- `backend-proxy-server/nginx/conf.d/vikunja.conf`: nginx 프록시 설정 추가

## 배포 순서

1. PR 머지
2. `terraform apply` (DNS 레코드 적용)
3. `backend-proxy-server` 재배포 (nginx conf 반영)
4. `manual-redeploy-vikunja` 워크플로우 실행

## 참고

- R2는 테스트용으로 기존 `PLANE_R2_*` 자격증명 임시 사용 중
- secrets-store PR은 별도 머지 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)