### PR TITLE
fix: vikunja-mcp 패키지를 @0xk3vin/vikunja-mcp으로 교체

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,9 +216,9 @@ services:
   vikunja-mcp:
     image: supercorp/supergateway
     container_name: vikunja-mcp
-    command: ["--stdio", "npx -y vikunja-mcp", "--port", "80", "--baseUrl", "https://www.montyoh.dev/api/mcp/vikunja"]
+    command: ["--stdio", "npx -y @0xk3vin/vikunja-mcp", "--port", "80", "--baseUrl", "https://www.montyoh.dev/api/mcp/vikunja"]
     environment:
-      VIKUNJA_API_BASE: http://vikunja:3456
+      VIKUNJA_URL: http://vikunja:3456
       VIKUNJA_API_TOKEN: ${VIKUNJA_API_TOKEN}
     networks:
       backend-network:


### PR DESCRIPTION
기존 vikunja-mcp의 list_project_tasks/list_all_tasks 버그로 task 목록 조회 불가. @0xk3vin/vikunja-mcp은 list 버그 없고
32개 툴, 86개 테스트, 이슈 1개로 가장 안정적.
환경변수: VIKUNJA_API_BASE → VIKUNJA_URL