### PR TITLE
fix: vikunja-mcp 재배포 시 다른 컨테이너 재생성 방지

### DIFF
--- a/.github/workflows/manual-redeploy-vikunja-mcp.yml
+++ b/.github/workflows/manual-redeploy-vikunja-mcp.yml
@@ -47,4 +47,4 @@ jobs:
             cd /home/ubuntu/app
             curl -L -o docker-compose.yml https://raw.githubusercontent.com/$DOCKER_REGISTRY_USERNAME/iac-terraform/refs/heads/master/docker-compose.yml
             docker-compose pull vikunja-mcp
-            docker-compose up -d vikunja-mcp
+            docker-compose up -d --no-recreate vikunja-mcp


### PR DESCRIPTION
## Summary
- `docker-compose up -d vikunja-mcp`에 `--no-recreate` 플래그 추가
- 재배포 시 이미 실행 중인 postgres, vikunja 등 다른 컨테이너가 불필요하게 재생성되는 문제 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)