### PR TITLE
fix: vikunja-mcp 재배포 워크플로우 원복 및 이미지 삭제 단계만 추가

### DIFF
--- a/.github/workflows/manual-redeploy-vikunja-mcp.yml
+++ b/.github/workflows/manual-redeploy-vikunja-mcp.yml
@@ -30,21 +30,23 @@ jobs:
 
       - name: Redeploy vikunja-mcp to Oracle
         uses: appleboy/ssh-action@v1
-        env:
-          DOCKER_REGISTRY_ACCESS_TOKEN: ${{ env.DOCKER_REGISTRY_ACCESS_TOKEN }}
-          DOCKER_REGISTRY_USERNAME: ${{ github.repository_owner }}
         with:
           host: ssh.montyoh.dev
           username: ubuntu
           key_path: ./secrets-store/key/ec2-ssh-key
-          envs: DOCKER_REGISTRY_ACCESS_TOKEN,DOCKER_REGISTRY_USERNAME
           script: |
+            ENV_JSON='${{ steps.set_env_json.outputs.ENV_VARS_JSON }}'
+            eval $(echo "$ENV_JSON" | jq -r '
+              to_entries[]
+              | select((.key | startswith("GITHUB_") | not) and (.key | startswith("RUNNER_") | not))
+              | "export \(.key)=\"\(.value)\";"
+            ' | tr -d '\n')
+
             docker ps -q --filter "name=vikunja-mcp" | xargs -r docker stop
             docker ps -a -q --filter "name=vikunja-mcp" | xargs -r docker rm
             docker images -q ghcr.io/$DOCKER_REGISTRY_USERNAME/vikunja-mcp:latest | xargs -r docker rmi -f
 
-            echo "$DOCKER_REGISTRY_ACCESS_TOKEN" | docker login ghcr.io -u $DOCKER_REGISTRY_USERNAME --password-stdin
             cd /home/ubuntu/app
-            curl -L -o docker-compose.yml https://raw.githubusercontent.com/$DOCKER_REGISTRY_USERNAME/iac-terraform/refs/heads/master/docker-compose.yml
-            docker-compose pull vikunja-mcp
-            docker-compose up -d --no-recreate vikunja-mcp
+            curl -L -o docker-compose.yml https://raw.githubusercontent.com/${{ github.repository_owner }}/iac-terraform/refs/heads/master/docker-compose.yml
+
+            docker-compose up -d vikunja-mcp


### PR DESCRIPTION
## Summary
- 원래 ENV_JSON 방식으로 원복
- 이미지 삭제 한 줄만 추가: `docker images -q ghcr.io/$DOCKER_REGISTRY_USERNAME/vikunja-mcp:latest | xargs -r docker rmi -f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)