### PR TITLE
feat: OCI 부트 볼륨 크기 200GB로 확장

### DIFF
--- a/oci/instance/instance.tf
+++ b/oci/instance/instance.tf
@@ -11,8 +11,9 @@ resource "oci_core_instance" "instance" {
   }
 
   source_details {
-    source_type = "image"
-    source_id   = var.image_id
+    source_type             = "image"
+    source_id               = var.image_id
+    boot_volume_size_in_gbs = var.boot_volume_size_in_gbs
   }
 
   create_vnic_details {

--- a/oci/instance/variable.tf
+++ b/oci/instance/variable.tf
@@ -1,10 +1,10 @@
-variable "compartment_id"      { type = string }
-variable "instance_name"       { type = string }
+variable "compartment_id" { type = string }
+variable "instance_name" { type = string }
 variable "availability_domain" { type = string }
-variable "image_id"            { type = string }
-variable "subnet_id"           { type = string }
-variable "ssh_public_key"      { type = string }
-variable "user_data"           { type = string }
+variable "image_id" { type = string }
+variable "subnet_id" { type = string }
+variable "ssh_public_key" { type = string }
+variable "user_data" { type = string }
 
 variable "ocpus" {
   type    = number
@@ -14,4 +14,9 @@ variable "ocpus" {
 variable "memory_in_gbs" {
   type    = number
   default = 6
+}
+
+variable "boot_volume_size_in_gbs" {
+  type    = number
+  default = 50
 }

--- a/oci/oci.tf
+++ b/oci/oci.tf
@@ -25,9 +25,10 @@ module "app_instance" {
   user_data = templatefile("${path.module}/../scripts/oci_application_instance_userdata.sh", {
     GHCR_TOKEN = var.GHCR_TOKEN
   })
-  ocpus         = 4
-  memory_in_gbs = 24
-  depends_on    = [module.networking]
+  ocpus                   = 4
+  memory_in_gbs           = 24
+  boot_volume_size_in_gbs = 200
+  depends_on              = [module.networking]
 }
 
 # 예산 알림


### PR DESCRIPTION
- instance: source_details에 boot_volume_size_in_gbs 추가
- 변수화 (default 50) 후 app_instance 모듈에서 200 주입
- Always Free 블록 스토리지 한도(200GB) 내

검증: terraform fmt clean, validate 통과