### PR TITLE
feat: Obsidian Vault 동기화용 R2 버킷 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# macOS
+.DS_Store
+
+# MCP tooling
+.playwright-mcp/
+
 # Local .terraform directories
 **/.terraform/*
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Terraform Cloud와 GitHub를 연동하여 실제 인프라에 배포합니다.
 
 ### Cloudflare
 - **DNS** (`montyoh.dev`): `root`, `www`, `ssh`, `db`, `payment`, `xcelerate`, `vikunja`, `affine`, 게임 서버(`valheim`, `corekeeper`, `palworld`) — 모두 OCI 인스턴스로 라우팅
-- **R2**: `common-static` → `static.montyoh.dev` (공통 정적 파일), `vikunja-static` → `vikunja.static.montyoh.dev` (Vikunja 파일 첨부), `affine-static` → `affine.static.montyoh.dev` (AFFiNE 파일 첨부)
+- **R2**: `common-static` → `static.montyoh.dev` (공통 정적 파일), `vikunja-static` → `vikunja.static.montyoh.dev` (Vikunja 파일 첨부), `affine-static` → `affine.static.montyoh.dev` (AFFiNE 파일 첨부), `obsidian-vault` (Obsidian Vault 동기화 — 비공개, S3 API 전용)
 - **Workers**: 서버 다운 시 점검 페이지 (`*montyoh.dev/*` 라우트)
 
 ---

--- a/cloudflare/cloudflare.tf
+++ b/cloudflare/cloudflare.tf
@@ -33,6 +33,13 @@ module "r2_affine" {
   zone_id               = var.CLOUDFLARE_ZONE_ID_MONTYOH_DEV
 }
 
+# R2 버킷 - Obsidian Vault 동기화 (비공개, Remotely Save S3 API 전용)
+module "r2_obsidian" {
+  source                = "./r2"
+  CLOUDFLARE_ACCOUNT_ID = var.CLOUDFLARE_ACCOUNT_ID
+  bucket_name           = "obsidian-vault"
+}
+
 # montyoh.dev 도메인 설정
 ##  루트 도메인 - 웹 접속
 resource "cloudflare_dns_record" "montyoh_dev_root" {

--- a/cloudflare/r2/r2.tf
+++ b/cloudflare/r2/r2.tf
@@ -33,8 +33,9 @@ resource "cloudflare_r2_bucket_cors" "cloudflare_r2_bucket_cors" {
   depends_on = [cloudflare_r2_bucket.cloudflare_r2_bucket]
 }
 
-# R2 커스텀 도메인 연결
+# R2 커스텀 도메인 연결 (domain 지정 시에만 생성)
 resource "cloudflare_r2_custom_domain" "cloudflare_r2_custom_domain" {
+  count       = var.domain != "" ? 1 : 0
   account_id  = var.CLOUDFLARE_ACCOUNT_ID
   bucket_name = cloudflare_r2_bucket.cloudflare_r2_bucket.name
   domain      = var.domain

--- a/cloudflare/r2/variable.tf
+++ b/cloudflare/r2/variable.tf
@@ -1,7 +1,13 @@
 variable "CLOUDFLARE_ACCOUNT_ID" { type = string }
 variable "bucket_name" { type = string }
-variable "domain" { type = string }
-variable "zone_id" { type = string }
+variable "domain" {
+  type    = string
+  default = ""
+}
+variable "zone_id" {
+  type    = string
+  default = ""
+}
 variable "cors_origins" {
   type    = list(string)
   default = []


### PR DESCRIPTION
- r2 모듈 domain/zone_id 옵셔널화 (count 기반 커스텀 도메인)
- obsidian-vault 버킷 추가 (비공개, Remotely Save S3 API 전용)
- .gitignore에 .DS_Store, .playwright-mcp/ 추가
- README R2 목록 갱신