### PR TITLE
feat: 스택에 proxy·vikunja·vikunja-mcp 추가 및 배포 워크플로 전환

### DIFF
--- a/.github/workflows/manual-redeploy-vikunja-mcp.yml
+++ b/.github/workflows/manual-redeploy-vikunja-mcp.yml
@@ -42,11 +42,8 @@ jobs:
               | "export \(.key)=\"\(.value)\";"
             ' | tr -d '\n')
 
-            docker ps -q --filter "name=vikunja-mcp" | xargs -r docker stop
-            docker ps -a -q --filter "name=vikunja-mcp" | xargs -r docker rm
-            docker images -q ghcr.io/$DOCKER_REGISTRY_USERNAME/vikunja-mcp:latest | xargs -r docker rmi -f
+            echo "$DOCKER_REGISTRY_ACCESS_TOKEN" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
 
             cd /home/ubuntu/app
-            curl -L -o docker-compose.yml https://raw.githubusercontent.com/${{ github.repository_owner }}/iac-terraform/refs/heads/master/docker-compose.yml
-
-            docker-compose up -d vikunja-mcp
+            curl -L -o docker-compose.stack.yml https://raw.githubusercontent.com/${{ github.repository_owner }}/iac-terraform/refs/heads/master/docker-compose.stack.yml
+            docker stack deploy --with-registry-auth -c docker-compose.stack.yml application-services

--- a/.github/workflows/manual-redeploy-vikunja.yml
+++ b/.github/workflows/manual-redeploy-vikunja.yml
@@ -87,11 +87,8 @@ jobs:
               | "export \(.key)=\"\(.value)\";"
             ' | tr -d '\n')
 
-            docker stop vikunja || true
-            docker rm vikunja || true
-
             cd /home/ubuntu/app
-            curl -L -o docker-compose.yml https://raw.githubusercontent.com/${{ github.repository_owner }}/iac-terraform/refs/heads/master/docker-compose.yml
+            curl -L -o docker-compose.stack.yml https://raw.githubusercontent.com/${{ github.repository_owner }}/iac-terraform/refs/heads/master/docker-compose.stack.yml
 
             # Vikunja 전용 유저 생성 (없을 경우에만)
             docker exec postgres psql -U "$DB_USERNAME" -d postgres -c \
@@ -111,7 +108,8 @@ jobs:
             docker exec postgres psql -U "$DB_USERNAME" -d postgres -c \
               "GRANT ALL PRIVILEGES ON DATABASE \"$VIKUNJA_DB_NAME\" TO \"$VIKUNJA_DB_USERNAME\";"
 
-            docker-compose up -d vikunja
+            echo "$DOCKER_REGISTRY_ACCESS_TOKEN" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
+            docker stack deploy --with-registry-auth -c docker-compose.stack.yml application-services
 
       - name: Register backup cron
         uses: appleboy/ssh-action@v1

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -12,6 +12,13 @@ x-deploy-defaults: &deploy-defaults
     max_attempts: 3
 
 services:
+  #   proxy
+  backend-proxy-server:
+    image: ghcr.io/dev-montyoh/backend-proxy-server:latest
+    ports:
+      - "80:80"
+    deploy: *deploy-defaults
+
   #   frontend
   ##  포트폴리오
   frontend-portfolio:
@@ -104,4 +111,38 @@ services:
       PAYMENT_INICIS_INIAPIKEY: ${PAYMENT_INICIS_INIAPIKEY}
       PAYMENT_NICEPAY_MERCHANT_KEY: ${PAYMENT_NICEPAY_MERCHANT_KEY}
       PAYMENT_NICEPAY_MID: ${PAYMENT_NICEPAY_MID}
+    deploy: *deploy-defaults
+
+  #   vikunja
+  ##  vikunja
+  vikunja:
+    image: vikunja/vikunja:latest
+    extra_hosts:
+      - "postgres:host-gateway"
+    environment:
+      VIKUNJA_DATABASE_TYPE: postgres
+      VIKUNJA_DATABASE_HOST: postgres
+      VIKUNJA_DATABASE_DATABASE: ${VIKUNJA_DB_NAME}
+      VIKUNJA_DATABASE_USER: ${VIKUNJA_DB_USERNAME}
+      VIKUNJA_DATABASE_PASSWORD: ${VIKUNJA_DB_PASSWORD}
+      VIKUNJA_SERVICE_SECRET: ${VIKUNJA_JWT_SECRET}
+      VIKUNJA_SERVICE_PUBLICURL: https://vikunja.montyoh.dev/
+      VIKUNJA_SERVICE_ENABLEREGISTRATION: "false"
+      VIKUNJA_SERVICE_CUSTOMLOGOURL: ${VIKUNJA_CUSTOM_LOGO_URL}
+      VIKUNJA_FILES_TYPE: s3
+      VIKUNJA_FILES_S3_ENDPOINT: ${CLOUDFLARE_R2_END_POINT}
+      VIKUNJA_FILES_S3_BUCKET: ${VIKUNJA_R2_BUCKET}
+      VIKUNJA_FILES_S3_REGION: auto
+      VIKUNJA_FILES_S3_ACCESSKEY: ${VIKUNJA_R2_ACCESS_KEY}
+      VIKUNJA_FILES_S3_SECRETKEY: ${VIKUNJA_R2_SECRET_KEY}
+      VIKUNJA_FILES_S3_USEPATHSTYLE: "true"
+    deploy: *deploy-defaults
+
+  ##  mcp
+  vikunja-mcp:
+    image: ghcr.io/dev-montyoh/vikunja-mcp:latest
+    environment:
+      VIKUNJA_URL: http://vikunja:3456/api/v1
+      VIKUNJA_TOKEN: ${VIKUNJA_API_TOKEN}
+      BASE_URL: https://www.montyoh.dev/api/mcp/vikunja
     deploy: *deploy-defaults


### PR DESCRIPTION
- docker-compose.stack.yml: backend-proxy-server(80 publish), vikunja(postgres host-gateway), vikunja-mcp 추가
- manual-redeploy-vikunja / -vikunja-mcp: 배포를 docker stack deploy로 전환 (백업·DB 생성·cron은 유지)